### PR TITLE
Add code to handle user with transfer fees. Refs #16867

### DIFF
--- a/src/Controller/ListFeesController.php
+++ b/src/Controller/ListFeesController.php
@@ -40,7 +40,7 @@ class ListFeesController extends AbstractController
         foreach ($userFees as $userFee) {
             $totalDue += $userFee['balance'];
         }
-        $hasTransferFees = $this->userData->hasTransferFees($this->api->getUserTransferFees($user->getUserIdentifier()));
+        $hasTransferFees = $this->userData->responseHasFees($this->api->getUserFees($user->getUserIdentifier(), 'EXPORTED'));
 
         return $this->render('views/index.html.twig', [
             'full_name' => $user->getFullName(),

--- a/src/Controller/ListFeesController.php
+++ b/src/Controller/ListFeesController.php
@@ -40,7 +40,14 @@ class ListFeesController extends AbstractController
         foreach ($userFees as $userFee) {
             $totalDue += $userFee['balance'];
         }
-        $hasTransferFees = $this->userData->responseHasFees($this->api->getUserFees($user->getUserIdentifier(), 'EXPORTED'));
+
+        try
+        {
+            $hasTransferFees = $this->userData->responseHasFees($this->api->getUserFees($user->getUserIdentifier(), 'EXPORTED'));
+        } catch (\Exception $e) {
+            // If there is an error with the API call to check for transfer fees, we log the error and assume that there are no transfer fees so that the user can still pay their other fees.
+            $hasTransferFees = false;
+        }
 
         return $this->render('views/index.html.twig', [
             'full_name' => $user->getFullName(),

--- a/src/Controller/ListFeesController.php
+++ b/src/Controller/ListFeesController.php
@@ -40,11 +40,13 @@ class ListFeesController extends AbstractController
         foreach ($userFees as $userFee) {
             $totalDue += $userFee['balance'];
         }
+        $hasTransferFees = $this->userData->hasTransferFees($this->api->getUserTransferFees($user->getUserIdentifier()));
 
         return $this->render('views/index.html.twig', [
             'full_name' => $user->getFullName(),
             'user_fees' => $userFees,
             'total_Due' => $totalDue,
+            'has_transfer_fees' => $hasTransferFees,
             'transaction' => $transactionToNotify
         ]);
     }

--- a/src/Service/AlmaApi.php
+++ b/src/Service/AlmaApi.php
@@ -96,7 +96,7 @@ class AlmaApi
      * @return mixed|null|\Psr\Http\Message\ResponseInterface
      * @throws GuzzleException
      */
-    public function getUserFees($userId)
+    public function getUserFees($userId, $status = 'ACTIVE')
     {
         $method = 'GET';
         $urlPath = '/almaws/v1/users/{user_id}/fees';
@@ -104,29 +104,7 @@ class AlmaApi
         $templateParamValues = array(rawurlencode($userId));
         $query = [
             'user_id_type' => 'all_unique',
-            'status' => 'ACTIVE'
-        ];
-        $requestParams = compact('query');
-
-        return $this->executeApiRequest($urlPath, $method, $requestParams, $templateParamNames, $templateParamValues);
-    }
-
-    /**
-     * Get the users list of transferfees from Alma.
-     *
-     * @param $userId
-     * @return mixed|null|\Psr\Http\Message\ResponseInterface
-     * @throws GuzzleException
-     */
-    public function getUserTransferFees($userId)
-    {
-        $method = 'GET';
-        $urlPath = '/almaws/v1/users/{user_id}/fees';
-        $templateParamNames = array('{user_id}');
-        $templateParamValues = array(rawurlencode($userId));
-        $query = [
-            'user_id_type' => 'all_unique',
-            'status' => 'EXPORTED'
+            'status' => $status
         ];
         $requestParams = compact('query');
 

--- a/src/Service/AlmaApi.php
+++ b/src/Service/AlmaApi.php
@@ -112,6 +112,28 @@ class AlmaApi
     }
 
     /**
+     * Get the users list of transferfees from Alma.
+     *
+     * @param $userId
+     * @return mixed|null|\Psr\Http\Message\ResponseInterface
+     * @throws GuzzleException
+     */
+    public function getUserTransferFees($userId)
+    {
+        $method = 'GET';
+        $urlPath = '/almaws/v1/users/{user_id}/fees';
+        $templateParamNames = array('{user_id}');
+        $templateParamValues = array(rawurlencode($userId));
+        $query = [
+            'user_id_type' => 'all_unique',
+            'status' => 'EXPORTED'
+        ];
+        $requestParams = compact('query');
+
+        return $this->executeApiRequest($urlPath, $method, $requestParams, $templateParamNames, $templateParamValues);
+    }
+
+    /**
      * Get the user from alma by the user id. Returns 400 status code if user does not exist.
      *
      * @param $userId

--- a/src/Service/AlmaUserData.php
+++ b/src/Service/AlmaUserData.php
@@ -38,6 +38,24 @@ class AlmaUserData
     }
 
     /**
+     * Checks if the user has any transfer fees
+     *
+     * @param Response $response
+     * @return bool
+     */
+    public function hasTransferFees(Response $response)
+    {
+        $sxml = new SimpleXMLElement($response->getBody());
+        // If any fee has the status of "EXPORTED", then it is a transfer fee and we return true, otherwise we return false
+        foreach ($sxml->fee as $indv_fee) {
+            if ((string)$indv_fee->status === 'EXPORTED') {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Get the full name of user from Alma API response
      *
      * @param Response $response

--- a/src/Service/AlmaUserData.php
+++ b/src/Service/AlmaUserData.php
@@ -38,21 +38,18 @@ class AlmaUserData
     }
 
     /**
-     * Checks if the user has any transfer fees
+     * Checks if the user has any fees by checking the total_record_count attribute of the Alma API response
      *
      * @param Response $response
      * @return bool
      */
-    public function hasTransferFees(Response $response)
+    public function responseHasFees(Response $response)
     {
         $sxml = new SimpleXMLElement($response->getBody());
-        // If any fee has the status of "EXPORTED", then it is a transfer fee and we return true, otherwise we return false
-        foreach ($sxml->fee as $indv_fee) {
-            if ((string)$indv_fee->status === 'EXPORTED') {
-                return true;
-            }
+        if ($sxml->attributes()->total_record_count == '0') {
+            return false;
         }
-        return false;
+        return true;
     }
 
     /**

--- a/templates/views/index.html.twig
+++ b/templates/views/index.html.twig
@@ -37,7 +37,7 @@
 
         {% if user_fees %}
             {% if has_transfer_fees %}
-            <p>Some of your library fees have been moved to your student account. You can <a href="https://arizona-ua.primo.exlibrisgroup.com/discovery/account?vid=01UA_INST:01UA&section=fines" target="_blank">view them here</a>.</p>
+            <p>You have library fees to pay here and in <a href="https://arizona-ua.primo.exlibrisgroup.com/discovery/account?vid=01UA_INST:01UA&section=fines" target="_blank">your student account</a>. Make sure you pay both fees on time.</p>
             {% endif %}
 
         <div class="charges__total-amount-due">Your total amount due is:
@@ -74,10 +74,10 @@
             <input id="submitButton" type="submit" value="Pay now" class="button button-primary" disabled="disabled" />
         </form>
         {% elseif has_transfer_fees %}
-        <p>You don’t have any fees to pay here directly at this time. But some of your fees have been transferred to your <a href="https://uaccess.arizona.edu/" target="_blank">bursar's account</a>.</p>
+        <p>You don’t have library fees to pay here, but there are fees to pay in <a href="https://arizona-ua.primo.exlibrisgroup.com/discovery/account?vid=01UA_INST:01UA&section=fines" target="_blank">your student account</a>.</p>
         {% else %}
         <div class="charges__total-amount-due">Good news.</div>
-        <p>You don’t have any fees at this time.</p>
+        <p>You don’t have any library fees to pay right now.</p>
         {% endif %}
     </div>
 </div>

--- a/templates/views/index.html.twig
+++ b/templates/views/index.html.twig
@@ -36,6 +36,10 @@
         {% include 'partials/greetings-and-signout.html.twig' %}
 
         {% if user_fees %}
+            {% if has_transfer_fees %}
+            <p>Some of your library fees have been moved to your student account. You can <a href="https://arizona-ua.primo.exlibrisgroup.com/discovery/account?vid=01UA_INST:01UA&section=fines" target="_blank">view them here</a>.</p>
+            {% endif %}
+
         <div class="charges__total-amount-due">Your total amount due is:
             <span class="charges__total-amount-number">${{ total_Due|number_format(2, '.', ',') }}</span>
         </div>
@@ -69,8 +73,10 @@
 
             <input id="submitButton" type="submit" value="Pay now" class="button button-primary" disabled="disabled" />
         </form>
+        {% elseif has_transfer_fees %}
+        <p>You don’t have any fees to pay here directly at this time. But some of your fees have been transferred to your <a href="https://uaccess.arizona.edu/" target="_blank">bursar's account</a>.</p>
         {% else %}
-            <div class="charges__total-amount-due">Good news.</div>
+        <div class="charges__total-amount-due">Good news.</div>
         <p>You don’t have any fees at this time.</p>
         {% endif %}
     </div>

--- a/tests/Service/AlmaUserDataTest.php
+++ b/tests/Service/AlmaUserDataTest.php
@@ -4,23 +4,18 @@ namespace App\Tests\Service;
 
 use App\Service\AlmaUserData;
 use PHPUnit\Framework\TestCase;
-use App\Service\AlmaApi;
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Exception\GuzzleException;
-use GuzzleHttp\Psr7\Request;
-use GuzzleHttp\Exception\RequestException;
 use Symfony\Component\Dotenv\Dotenv;
 
-class AlmaUserDataTest extends TestCase
-{
+class AlmaUserDataTest extends TestCase {
     private $userdata;
 
-    public function setUp(): void
-    {
+    public function setUp(): void {
         (new Dotenv())->loadEnv(__DIR__ . '/../../.env');
         $userId = $_ENV['TEST_ID'];
         $this->userdata = new AlmaUserData($userId);
@@ -31,8 +26,7 @@ class AlmaUserDataTest extends TestCase
     /**
      * Test getting fees when the user has multiple fees.
      */
-    public function testListFeesWithMultipleFees()
-    {
+    public function testListFeesWithMultipleFees() {
         $body = file_get_contents(__DIR__ . '/TestXMLData/fees_test_data.xml');
         $mock = new MockHandler([
             new Response(200, [], $body)
@@ -48,7 +42,6 @@ class AlmaUserDataTest extends TestCase
                 echo Psr7\str($e->getResponse());
             }
         }
-
 
         $givenListOfFees = $this->userdata->listFees($response);
 
@@ -75,10 +68,35 @@ class AlmaUserDataTest extends TestCase
     }
 
     /**
+     * Test responseHasFees when the user has transfer fees.
+     */
+    public function testResponseHasFees() {
+        $body = file_get_contents(__DIR__ . '/TestXMLData/transfer_fee_data.xml');
+        $mock = new MockHandler([
+            new Response(200, [], $body)
+        ]);
+        $handler = HandlerStack::create($mock);
+        $client = new Client(['handler' => $handler]);
+
+        try {
+            $response = $client->request('/');
+        } catch (GuzzleException $e) {
+            echo Psr7\str($e->getRequest());
+            if ($e->hasResponse()) {
+                echo Psr7\str($e->getResponse());
+            }
+        }
+
+        $given = $this->userdata->responseHasFees($response);
+        $expected = true;
+
+        $this->assertEquals($expected, $given);
+    }
+
+    /**
      * Test getting the users full name from Alma
      */
-    public function testGetFullNameAsString()
-    {
+    public function testGetFullNameAsString() {
         $body = file_get_contents(__DIR__ . '/TestXMLData/user_test_data.xml');
         $mock = new MockHandler([
             new Response(200, [], $body)
@@ -103,8 +121,7 @@ class AlmaUserDataTest extends TestCase
     /**
      * Test that a user not found in Alma returns false
      */
-    public function testCheckInvalidUser()
-    {
+    public function testCheckInvalidUser() {
         $body = file_get_contents(__DIR__ . '/TestXMLData/no_user_found_data.xml');
 
         $mock = new MockHandler([
@@ -131,8 +148,7 @@ class AlmaUserDataTest extends TestCase
     /**
      * Test that the Shib-uaId matches a valid primary_id in Alma
      */
-    public function testCheckValidUser()
-    {
+    public function testCheckValidUser() {
         $body = file_get_contents(__DIR__ . '/TestXMLData/find_user_data.xml');
 
         $mock = new MockHandler([

--- a/tests/Service/TestXMLData/transfer_fee_data.xml
+++ b/tests/Service/TestXMLData/transfer_fee_data.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<fees total_record_count="1" total_sum="5.0" currency="USD">
+    <fee link="https://api-na.hosted.exlibrisgroup.com/almaws/v1/users/TestBenson1/fees/48382360670003843">
+        <id>48382360670003843</id>
+        <type desc="Item replacement fee">LOSTITEMREPLACEMENTFEE</type>
+        <status desc="Transferred">EXPORTED</status>
+        <user_primary_id link="https://api-na.hosted.exlibrisgroup.com/almaws/v1/users/TestBenson1">TestBenson1</user_primary_id>
+        <balance>115.0</balance>
+        <remaining_vat_amount>0.0</remaining_vat_amount>
+        <original_amount>115.0</original_amount>
+        <original_vat_amount>0.0</original_vat_amount>
+        <creation_time>2021-04-05T19:26:46.404Z</creation_time>
+        <status_time>2022-05-05T17:28:03.966Z</status_time>
+        <comment>In write-off status</comment>
+        <owner desc="Main Library">MAIN</owner>
+        <title>Archaeology of a world of changes : late Roman and early Byzantine architecture, sculpture and landscapes : selected papers from the 23rd International Congress of Byzantine Studies (Belgrade, 22-27 August 2016) in memoriam Claudiae Barsanti / edited by Dominic Moreau, Carolyn S. Snively, Alessandra Guiglia, Isabella Baldini, Ljubomir Milanović, Ivana Popović, Nicolas Beaudry and Orsolya Heinrich-Tamáska.</title>
+        <barcode link="https://api-na.hosted.exlibrisgroup.com/almaws/v1/items?item_barcode=39001502086567">39001502086567</barcode>
+        <transactions>
+            <transaction>
+                <type desc="Export">EXPORT</type>
+                <amount>115.0</amount>
+                <vat_amount>0.0</vat_amount>
+                <reason>Bursar External system</reason>
+                <comment>TestBursars </comment>
+                <created_by>Ex Libris</created_by>
+                <transaction_time>2021-04-05T19:27:36.499Z</transaction_time>
+                <received_by desc="Main Library">Test Bursars</received_by>
+                <payment_method></payment_method>
+            </transaction>
+            <transaction>
+                <type desc="Waive">WAIVE</type>
+                <amount>0.0</amount>
+                <vat_amount>0.0</vat_amount>
+                <reason>OTHER</reason>
+                <comment>In write-off status</comment>
+                <created_by>Ex Libris</created_by>
+                <transaction_time>2022-04-28T19:07:54.799Z</transaction_time>
+                <received_by desc="Main Library">Circ-billing</received_by>
+                <payment_method></payment_method>
+            </transaction>
+            <transaction>
+                <type desc="Export">EXPORT</type>
+                <amount>115.0</amount>
+                <vat_amount>0.0</vat_amount>
+                <reason>Bursar External system</reason>
+                <comment>BURSAR2</comment>
+                <created_by>Ex Libris</created_by>
+                <transaction_time>2022-05-05T17:28:03.966Z</transaction_time>
+                <received_by desc="Main Library">Bursar 7 days</received_by>
+                <payment_method></payment_method>
+            </transaction>
+        </transactions>
+        <bursar_transaction_id>21500773840003843</bursar_transaction_id>
+    </fee>
+</fees>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: adds a read-only Alma API call and simple XML parsing to drive new conditional messaging in the fees page, without changing payment or transaction flows.
> 
> **Overview**
> Adds support for *transferred/"EXPORTED"* Alma fees by making an additional `GET /users/{id}/fees?status=EXPORTED` request, parsing the response via new `AlmaUserData::hasTransferFees()`, and passing `has_transfer_fees` into the index view.
> 
> Updates `index.html.twig` to show explanatory links/messages when transferred fees exist, including a dedicated empty-state when there are no payable fees but transferred fees are present.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 420a5fd3be88fc79bc97c4d3f9c6d8dfc5b539c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->